### PR TITLE
Fixed indentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,16 +38,16 @@ categories : [piston]
         <h3>Rectangle Example</h3>
         
         {% highlight Rust %}
-        use graphics::*;
-        use piston::{Game, Gl};
-        
-        pub struct App { ... } // your application data
-        
-        impl Game for App {
-            fn render(&self, c: &Context, gl: &mut Gl) {
-                c.rect(0.0, 0.0, 0.5, 0.5).rgb(1.0, 0.0, 0.0).fill(gl);
-            }
-        }
+use graphics::*;
+use piston::{Game, Gl};
+
+pub struct App { ... } // your application data
+
+impl Game for App {
+    fn render(&self, c: &Context, gl: &mut Gl) {
+        c.rect(0.0, 0.0, 0.5, 0.5).rgb(1.0, 0.0, 0.0).fill(gl);
+    }
+}
         {% endhighlight %}
          
         <p><a href="https://github.com/PistonDevelopers/piston">View on Github</a></p>   


### PR DESCRIPTION
It seems the indentation that I did earlier on the home page did not work well with the source code example. Jekyll thought that the spaces in frot were part of the code to be highlighted and as a result, the output had spaces in front.

This is a temporary fix while I continue to look further into Jekyll's highlighting system. I'm also looking into the possibility of writing the pages in Markdown, rather than HTML.
