### PR TITLE
Capitalize the name of the language consistently

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ categories : [piston]
   <head>
     <meta charset='utf-8' />
     <meta http-equiv="X-UA-Compatible" content="chrome=1" />
-    <meta name="description" content="Piston: A user friendly game engine written in rust" />
+    <meta name="description" content="Piston: A user friendly game engine written in Rust" />
 
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
@@ -23,7 +23,7 @@ categories : [piston]
           <a id="forkme_banner" href="https://github.com/PistonDevelopers/Piston">View on GitHub</a>
 
           <h1 id="project_title">Piston</h1>
-          <h2 id="project_tagline">A user friendly game engine written in rust</h2>
+          <h2 id="project_tagline">A user friendly game engine written in Rust</h2>
 
         </header>
     </div>


### PR DESCRIPTION
I prefer to always capitalize Rust, when speaking about the language, particularly in marketing material or official documentation.
