### PR TITLE
Update Travis CI badge branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piston Website [![Build Status](https://travis-ci.org/PistonDevelopers/pistondevelopers.github.io.svg)](https://travis-ci.org/PistonDevelopers/pistondevelopers.github.io)
+# Piston Website [![Build Status](https://travis-ci.org/PistonDevelopers/pistondevelopers.github.io.svg?branch=master)](https://travis-ci.org/PistonDevelopers/pistondevelopers.github.io)
 
 This is the repository that contains the piston website and related documentation.
 


### PR DESCRIPTION
Points Travis CI at master to avoid erroneous "Build Failed" messages
