### PR TITLE
Fix HTTP URLs to be HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@ categories : [piston]
         <ul class="nav navbar-nav navbar-right piston-navbar-nav">
           <li class="active"><a href="#">Home</a></li>
           <li><a href="https://github.com/PistonDevelopers/Piston-Tutorials/tree/master/getting-started">Getting Started</a></li>
-          <li><a href="http://docs.piston.rs/">Documentation</a></li>
-          <li><a href="http://blog.piston.rs/">Blog</a></li>
+          <li><a href="https://docs.piston.rs/">Documentation</a></li>
+          <li><a href="https://blog.piston.rs/">Blog</a></li>
           <li><a href="https://github.com/PistonDevelopers/piston/blob/master/CONTRIBUTING.md">Contribute</a></li>
         </ul>
       </div>
@@ -131,7 +131,7 @@ fn main() {
         Loading..
       </ul>
 
-      <a href="http://blog.piston.rs/" class="piston-more pull-right">More posts &raquo;</a>
+      <a href="https://blog.piston.rs/" class="piston-more pull-right">More posts &raquo;</a>
     </div>
   </div>
 


### PR DESCRIPTION
Fixes https://github.com/PistonDevelopers/piston/issues/1246

cc @leonkunert 

Probably a better long term solution to this problem would be to configure the server to redirect all HTTP requests to HTTPS, so that it didn't matter which the user typed in.